### PR TITLE
fix: persist queued webhook activities + DELETE journal mode for NAS data dir

### DIFF
--- a/__tests__/database/connection.test.js
+++ b/__tests__/database/connection.test.js
@@ -1,0 +1,46 @@
+const path = require('path');
+const fs = require('fs').promises;
+const os = require('os');
+
+jest.mock('../../src/utils/Logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}));
+
+jest.mock('../../config/config', () => ({
+  database: {
+    path: ''
+  }
+}));
+
+const config = require('../../config/config');
+const dbConnection = require('../../src/database/connection');
+
+describe('DatabaseConnection', () => {
+  let testDataDir;
+
+  beforeEach(async () => {
+    testDataDir = path.join(os.tmpdir(), `db_connection_test_${Date.now()}`);
+    await fs.mkdir(testDataDir, { recursive: true });
+    config.database.path = path.join(testDataDir, 'test.db');
+  });
+
+  afterEach(async () => {
+    await dbConnection.close();
+    await fs.rm(testDataDir, { recursive: true, force: true });
+  });
+
+  // WAL mode depends on mmap-based shared-memory coordination between the
+  // -wal/-shm files, which network/FUSE-backed volumes (the production NAS
+  // deployment keeps its data dir on a network share) don't reliably
+  // support. DELETE mode uses plain file I/O and has no such dependency.
+  it('should use DELETE journal mode, not WAL', async () => {
+    await dbConnection.initialize();
+
+    const raw = dbConnection.getRawDb();
+    const result = raw.pragma('journal_mode');
+
+    expect(result[0].journal_mode.toLowerCase()).toBe('delete');
+  });
+});

--- a/__tests__/managers/ActivityQueue.test.js
+++ b/__tests__/managers/ActivityQueue.test.js
@@ -200,26 +200,25 @@ describe('ActivityQueue', () => {
       await activityQueue.queueActivity(activityId, athleteId);
     });
 
-    it('should process queued activity successfully', async () => {
+    it('should delegate to processNewActivity so queued activities get the full pipeline', async () => {
       await activityQueue.processQueuedActivity(activityId);
 
-      expect(mockMemberManager.getMemberByAthleteId).toHaveBeenCalledWith(athleteId);
-      expect(mockMemberManager.getValidAccessToken).toHaveBeenCalledWith(mockMember);
-      expect(mockStravaAPI.getActivity).toHaveBeenCalledWith(activityId, 'valid_token');
-      expect(mockStravaAPI.shouldPostActivity).toHaveBeenCalledWith(mockActivity);
-      expect(mockStravaAPI.processActivityWithStreams).toHaveBeenCalledWith(
-        mockActivity,
-        expect.objectContaining({
-          ...mockMember.athlete,
-          discordUser: mockMember.discordUser
-        }),
-        'valid_token'
-      );
-      expect(mockDiscordBot.postActivity).toHaveBeenCalledWith(mockActivity);
-      expect(mockActivityProcessor.processedActivities.has(`${athleteId}-${activityId}`)).toBe(true);
-      
-      expect(logger.activity.info).toHaveBeenCalledWith('Successfully posted queued activity', expect.any(Object));
+      expect(mockActivityProcessor.processNewActivity).toHaveBeenCalledWith(activityId, athleteId);
       expect(activityQueue.queuedActivities.size).toBe(0);
+    });
+
+    it('should not duplicate the processing pipeline in the queue', async () => {
+      // processNewActivity owns member checks, token refresh, PB detection,
+      // DB persistence, post-filtering and Discord posting. The queue must not
+      // reimplement any of it: a previous duplicated path silently skipped
+      // upsertActivity and PB checks for every delayed post.
+      await activityQueue.processQueuedActivity(activityId);
+
+      expect(mockMemberManager.getMemberByAthleteId).not.toHaveBeenCalled();
+      expect(mockMemberManager.getValidAccessToken).not.toHaveBeenCalled();
+      expect(mockStravaAPI.getActivity).not.toHaveBeenCalled();
+      expect(mockStravaAPI.shouldPostActivity).not.toHaveBeenCalled();
+      expect(mockDiscordBot.postActivity).not.toHaveBeenCalled();
     });
 
     it('should handle missing queue item gracefully', async () => {
@@ -228,123 +227,26 @@ describe('ActivityQueue', () => {
       await activityQueue.processQueuedActivity(activityId);
 
       expect(logger.activity.warn).toHaveBeenCalledWith('Queued activity not found when processing', { activityId });
-      expect(mockMemberManager.getMemberByAthleteId).not.toHaveBeenCalled();
+      expect(mockActivityProcessor.processNewActivity).not.toHaveBeenCalled();
     });
 
-    it('should skip processing if athlete is no longer registered', async () => {
-      mockMemberManager.getMemberByAthleteId.mockResolvedValue(null);
-
-      await activityQueue.processQueuedActivity(activityId);
-
-      expect(logger.activity.warn).toHaveBeenCalledWith('Athlete no longer registered, skipping queued activity', {
-        activityId,
-        athleteId
-      });
-      expect(mockStravaAPI.getActivity).not.toHaveBeenCalled();
-      expect(activityQueue.queuedActivities.size).toBe(0);
-    });
-
-    it('should skip processing if unable to get valid access token', async () => {
-      mockMemberManager.getValidAccessToken.mockResolvedValue(null);
-
-      await activityQueue.processQueuedActivity(activityId);
-
-      expect(logger.activity.error).toHaveBeenCalledWith('Unable to get valid access token for queued activity', {
-        activityId,
-        athleteId,
-        memberName: 'Test User'
-      });
-      expect(mockStravaAPI.getActivity).not.toHaveBeenCalled();
-      expect(activityQueue.queuedActivities.size).toBe(0);
-    });
-
-    it('should skip processing if activity no longer meets posting criteria', async () => {
-      mockStravaAPI.shouldPostActivity.mockReturnValue(false);
-
-      await activityQueue.processQueuedActivity(activityId);
-
-      expect(logger.activity.info).toHaveBeenCalledWith('Activity no longer meets posting criteria, skipping', {
-        activityId,
-        activityName: mockActivity.name,
-        memberName: 'Test User'
-      });
-      expect(mockDiscordBot.postActivity).not.toHaveBeenCalled();
-      expect(activityQueue.queuedActivities.size).toBe(0);
-    });
-
-    it('should update queue item status to processing', async () => {
-      // Mock a delay in processing to check status
-      mockStravaAPI.getActivity.mockImplementation(async () => {
+    it('should update queue item status to processing before delegating', async () => {
+      mockActivityProcessor.processNewActivity.mockImplementation(async () => {
         const queueItem = activityQueue.queuedActivities.get(activityId);
         expect(queueItem.status).toBe('processing');
-        return mockActivity;
       });
 
       await activityQueue.processQueuedActivity(activityId);
-    });
 
-    it('should handle member without Discord user data', async () => {
-      const memberWithoutDiscord = {
-        ...mockMember,
-        discordUser: null
-      };
-      mockMemberManager.getMemberByAthleteId.mockResolvedValue(memberWithoutDiscord);
-
-      await activityQueue.processQueuedActivity(activityId);
-
-      expect(mockStravaAPI.processActivityWithStreams).toHaveBeenCalledWith(
-        mockActivity,
-        expect.objectContaining({
-          ...mockMember.athlete,
-          discordUser: null
-        }),
-        'valid_token'
-      );
-      expect(mockDiscordBot.postActivity).toHaveBeenCalled();
-    });
-
-    it('should calculate correct delay time in logs', async () => {
-      // Set initial time when queuing
-      const queueTime = new Date('2024-01-01T12:00:00Z');
-      jest.setSystemTime(queueTime);
-      
-      // Clear and re-queue to get fresh timestamp
-      activityQueue.queuedActivities.clear();
-      await activityQueue.queueActivity(activityId, athleteId);
-      
-      // Advance time by 10 minutes
-      const processTime = new Date('2024-01-01T12:10:00Z');
-      jest.setSystemTime(processTime);
-
-      await activityQueue.processQueuedActivity(activityId);
-
-      expect(logger.activity.info).toHaveBeenCalledWith('Successfully posted queued activity', 
-        expect.objectContaining({
-          delayedBy: '10 minutes'
-        })
-      );
+      expect(mockActivityProcessor.processNewActivity).toHaveBeenCalledWith(activityId, athleteId);
     });
 
     describe('error handling', () => {
-      it('should handle Strava API errors', async () => {
-        const error = new Error('Strava API error');
-        mockStravaAPI.getActivity.mockRejectedValue(error);
+      it('should log processing errors and clear the queue entry without rethrowing', async () => {
+        const error = new Error('processing failed');
+        mockActivityProcessor.processNewActivity.mockRejectedValue(error);
 
-        await activityQueue.processQueuedActivity(activityId);
-
-        expect(logger.activity.error).toHaveBeenCalledWith('Error processing queued activity', {
-          activityId,
-          error: error.message,
-          stack: error.stack
-        });
-        expect(activityQueue.queuedActivities.size).toBe(0);
-      });
-
-      it('should handle Discord posting errors', async () => {
-        const error = new Error('Discord API error');
-        mockDiscordBot.postActivity.mockRejectedValue(error);
-
-        await activityQueue.processQueuedActivity(activityId);
+        await expect(activityQueue.processQueuedActivity(activityId)).resolves.toBeUndefined();
 
         expect(logger.activity.error).toHaveBeenCalledWith('Error processing queued activity', {
           activityId,
@@ -352,16 +254,14 @@ describe('ActivityQueue', () => {
           stack: error.stack
         });
         expect(activityQueue.queuedActivities.size).toBe(0);
+        expect(activityQueue.timers.size).toBe(0);
       });
 
-      it('should handle member manager errors', async () => {
-        const error = new Error('Database connection failed');
-        mockMemberManager.getMemberByAthleteId.mockRejectedValue(error);
-
+      it('should remove the activity from the queue after successful processing', async () => {
         await activityQueue.processQueuedActivity(activityId);
 
-        expect(logger.activity.error).toHaveBeenCalledWith('Error processing queued activity', expect.any(Object));
         expect(activityQueue.queuedActivities.size).toBe(0);
+        expect(activityQueue.timers.size).toBe(0);
       });
     });
   });

--- a/src/database/connection.js
+++ b/src/database/connection.js
@@ -39,8 +39,13 @@ class DatabaseConnection {
       logger.info(`Connecting to database at: ${finalDbPath}`);
       
       this.db = new Database(finalDbPath);
-      this.db.exec('PRAGMA journal_mode = WAL;');
+      // DELETE journal mode: WAL depends on mmap-based shared memory (-shm),
+      // which network/FUSE-backed volumes (the production data dir is a NAS
+      // share) don't reliably support. DELETE uses plain file I/O only.
+      this.db.exec('PRAGMA journal_mode = DELETE;');
       this.db.exec('PRAGMA synchronous = NORMAL;');
+      const journalMode = this.db.pragma('journal_mode', { simple: true });
+      logger.info(`SQLite journal mode: ${journalMode}`);
       
       // Run migrations first
       await this.runMigrations();

--- a/src/managers/ActivityQueue.js
+++ b/src/managers/ActivityQueue.js
@@ -66,102 +66,38 @@ class ActivityQueue {
   }
 
   /**
-   * Process a queued activity (fetch latest data and post to Discord)
+   * Process a queued activity once its delay elapses. Delegates to
+   * processNewActivity — the single pipeline that also records PBs and
+   * persists the activity to the database — so delayed posts behave exactly
+   * like immediate ones. The queue must not reimplement any of that pipeline.
    */
   async processQueuedActivity(activityId) {
+    const queueItem = this.queuedActivities.get(activityId);
+    if (!queueItem) {
+      logger.activity.warn('Queued activity not found when processing', { activityId });
+      return;
+    }
+
+    logger.activity.info('Processing queued activity', {
+      activityId,
+      athleteId: queueItem.athleteId,
+      queuedAt: queueItem.queuedAt,
+      scheduledTime: queueItem.scheduledTime
+    });
+
+    queueItem.status = 'processing';
+
     try {
-      const queueItem = this.queuedActivities.get(activityId);
-      if (!queueItem) {
-        logger.activity.warn('Queued activity not found when processing', { activityId });
-        return;
-      }
-
-      logger.activity.info('Processing queued activity', {
-        activityId,
-        athleteId: queueItem.athleteId,
-        queuedAt: queueItem.queuedAt,
-        scheduledTime: queueItem.scheduledTime
-      });
-
-      // Update status
-      queueItem.status = 'processing';
-
-      // Check if athlete is still a registered member
-      const member = await this.activityProcessor.memberManager.getMemberByAthleteId(queueItem.athleteId);
-      if (!member) {
-        logger.activity.warn('Athlete no longer registered, skipping queued activity', {
-          activityId,
-          athleteId: queueItem.athleteId
-        });
-        this.removeFromQueue(activityId);
-        return;
-      }
-
-      const memberName = member.discordUser ? member.discordUser.displayName : `${member.athlete.firstname} ${member.athlete.lastname}`;
-
-      // Get valid access token
-      const accessToken = await this.activityProcessor.memberManager.getValidAccessToken(member);
-      if (!accessToken) {
-        logger.activity.error('Unable to get valid access token for queued activity', {
-          activityId,
-          athleteId: queueItem.athleteId,
-          memberName
-        });
-        this.removeFromQueue(activityId);
-        return;
-      }
-
-      // Fetch the latest activity data from Strava
-      logger.activity.debug('Fetching updated activity data before posting', {
-        activityId,
-        memberName
-      });
-
-      const activity = await this.activityProcessor.stravaAPI.getActivity(activityId, accessToken);
-      
-      // Check if activity should still be posted (might have been made private, etc.)
-      if (!this.activityProcessor.stravaAPI.shouldPostActivity(activity)) {
-        logger.activity.info('Activity no longer meets posting criteria, skipping', {
-          activityId,
-          activityName: activity.name,
-          memberName
-        });
-        this.removeFromQueue(activityId);
-        return;
-      }
-
-      // Process activity data for Discord with member info
-      const athleteWithDiscordInfo = {
-        ...member.athlete,
-        discordUser: member.discordUser
-      };
-      const processedActivity = await this.activityProcessor.stravaAPI.processActivityWithStreams(activity, athleteWithDiscordInfo, accessToken);
-
-      // Post to Discord
-      await this.activityProcessor.discordBot.postActivity(processedActivity);
-
-      // Mark as processed in the main processor to prevent duplicate processing
-      const activityKey = `${queueItem.athleteId}-${activityId}`;
-      this.activityProcessor.processedActivities.add(activityKey);
-
-      logger.activity.info('Successfully posted queued activity', {
-        activityId,
-        activityName: activity.name,
-        memberName,
-        delayedBy: `${Math.round((Date.now() - queueItem.queuedAt.getTime()) / 1000 / 60)} minutes`
-      });
-
-      // Clean up
-      this.removeFromQueue(activityId);
-
+      await this.activityProcessor.processNewActivity(activityId, queueItem.athleteId);
     } catch (error) {
       logger.activity.error('Error processing queued activity', {
         activityId,
         error: error.message,
         stack: error.stack
       });
-      
-      // Remove from queue to prevent retry loops
+    } finally {
+      // Always clear the entry — success, filtered, or failed — to prevent
+      // stale timers and retry loops.
       this.removeFromQueue(activityId);
     }
   }


### PR DESCRIPTION
## Problem

The July 1st monthly leaderboard posted "No running activities recorded for any team member" for June 2026, despite activities posting to Discord all month.

## Root cause (verified against the production DB and container logs)

`ActivityQueue.processQueuedActivity()` reimplemented the posting flow and **skipped PB detection and the `activities`-table upsert entirely**. With `POSTING_DELAY_MINUTES > 0` in production, every webhook activity took this path — so since the feature shipped (May 18), **not one webhook activity was ever persisted**. The leaderboard reads only the `activities` table, hence the empty June post. Container logs confirm: 264 webhook events processed since June 26, zero DB save attempts, zero errors.

## Fix

- `ActivityQueue.processQueuedActivity` now delegates to `ActivityProcessor.processNewActivity` — the single pipeline that records PBs, persists the activity, applies the post filter, and posts to Discord (net −159 lines, removes the duplicated flow).
- SQLite journal mode switched WAL → DELETE: the production data dir lives on a NAS network share where WAL's mmap/-shm dependency is unreliable; DELETE uses plain file I/O. The effective mode is now logged at startup.

## Tests

- Rewrote `ActivityQueue.processQueuedActivity` tests to pin the delegation contract (queue must not duplicate the pipeline).
- New `connection.test.js` asserting DELETE journal mode.
- Full suite: 972/972 passing; eslint clean.

## Recovery (after deploy)

Each member runs `/sync period:previous_month` to backfill June from Strava, then `/leaderboard month:previous` re-shows June (during July).

🤖 Generated with [Claude Code](https://claude.com/claude-code)