### PR TITLE
feat: admin all_members option for /sync (team-wide backfill)

### DIFF
--- a/__tests__/discord/commands.test.js
+++ b/__tests__/discord/commands.test.js
@@ -100,6 +100,18 @@ jest.mock('discord.js', () => {
         mockCmd.options.push(option);
         return mockCmd;
       }),
+      addBooleanOption: jest.fn().mockImplementation((callback) => {
+        const option = {
+          name: '',
+          required: false,
+          setName: jest.fn().mockImplementation((name) => { option.name = name; return option; }),
+          setDescription: jest.fn().mockReturnThis(),
+          setRequired: jest.fn().mockImplementation((req) => { option.required = req; return option; })
+        };
+        callback(option);
+        mockCmd.options.push(option);
+        return mockCmd;
+      }),
       setDefaultMemberPermissions: jest.fn().mockImplementation((perms) => {
         mockCmd.default_member_permissions = String(perms);
         return mockCmd;
@@ -1537,6 +1549,7 @@ describe('DiscordCommands', () => {
         editReply: jest.fn().mockResolvedValue(undefined),
         options: {
           getString: jest.fn((name) => (name === 'period' ? 'current_year' : null)),
+          getBoolean: jest.fn().mockReturnValue(null),
         },
       };
       mockMemberManager.getMemberByDiscordId.mockResolvedValue({
@@ -1756,6 +1769,175 @@ describe('DiscordCommands', () => {
       expect(syncInteraction.editReply).toHaveBeenCalledWith(
         expect.objectContaining({ content: expect.stringContaining('Failed') })
       );
+    });
+  });
+
+  // ─── handleSyncCommand — all_members (admin bulk sync) ─────────────────────
+
+  describe('handleSyncCommand with all_members', () => {
+    let bulkInteraction;
+    const memberAlice = {
+      discordUserId: '111',
+      athleteId: 1,
+      isActive: true,
+      discordUser: { displayName: 'Alice' },
+      athlete: { firstname: 'Alice', lastname: 'Runner' },
+    };
+    const memberBob = {
+      discordUserId: '222',
+      athleteId: 2,
+      isActive: true,
+      discordUser: null,
+      athlete: { firstname: 'Bob', lastname: 'Jogger' },
+    };
+
+    beforeEach(() => {
+      bulkInteraction = {
+        user: { tag: 'Admin#1234', id: '999999999' },
+        memberPermissions: { has: jest.fn().mockReturnValue(true) },
+        deferReply: jest.fn().mockResolvedValue(undefined),
+        editReply: jest.fn().mockResolvedValue(undefined),
+        options: {
+          getString: jest.fn((name) => (name === 'period' ? 'previous_month' : null)),
+          getBoolean: jest.fn((name) => (name === 'all_members' ? true : null)),
+        },
+      };
+      mockMemberManager.getAllMembers.mockResolvedValue([memberAlice, memberBob]);
+      mockMemberManager.getValidAccessToken.mockResolvedValue('valid_token');
+      discordCommands.pbManager.syncFromHistory.mockResolvedValue({ processed: 3, updated: 1, errors: 0 });
+    });
+
+    it('rejects users without Manage Server permission', async () => {
+      bulkInteraction.memberPermissions.has.mockReturnValue(false);
+
+      await discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options);
+
+      expect(bulkInteraction.memberPermissions.has).toHaveBeenCalledWith(PermissionFlagsBits.ManageGuild);
+      expect(bulkInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Manage Server') })
+      );
+      expect(discordCommands.pbManager.syncFromHistory).not.toHaveBeenCalled();
+    });
+
+    it('treats missing memberPermissions (e.g. DM context) as non-admin', async () => {
+      bulkInteraction.memberPermissions = null;
+
+      await discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options);
+
+      expect(discordCommands.pbManager.syncFromHistory).not.toHaveBeenCalled();
+    });
+
+    it('syncs every registered member with the resolved window', async () => {
+      await discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options);
+
+      const now = new Date();
+      const expectedAfter = Math.floor(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1) / 1000);
+      const expectedBefore = Math.floor(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1) / 1000);
+
+      expect(discordCommands.pbManager.syncFromHistory).toHaveBeenCalledTimes(2);
+      expect(discordCommands.pbManager.syncFromHistory).toHaveBeenCalledWith(
+        '111', 'valid_token', mockStravaAPI, null, expectedAfter, expectedBefore
+      );
+      expect(discordCommands.pbManager.syncFromHistory).toHaveBeenCalledWith(
+        '222', 'valid_token', mockStravaAPI, null, expectedAfter, expectedBefore
+      );
+      expect(bulkInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ embeds: expect.any(Array) })
+      );
+    });
+
+    it('supports an explicit month window', async () => {
+      bulkInteraction.options.getString.mockImplementation((name) => {
+        if (name === 'period') return 'current_year';
+        if (name === 'month') return '2026-06';
+        return null;
+      });
+
+      await discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options);
+
+      const expectedAfter = Math.floor(Date.UTC(2026, 5, 1) / 1000);
+      const expectedBefore = Math.floor(Date.UTC(2026, 6, 1) / 1000);
+      const [, , , , calledAfter, calledBefore] = discordCommands.pbManager.syncFromHistory.mock.calls[0];
+      expect(calledAfter).toBe(expectedAfter);
+      expect(calledBefore).toBe(expectedBefore);
+    });
+
+    it('rejects an invalid month window without syncing', async () => {
+      bulkInteraction.options.getString.mockImplementation((name) => {
+        if (name === 'period') return 'current_year';
+        if (name === 'month') return 'June-2026';
+        return null;
+      });
+
+      await discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options);
+
+      expect(discordCommands.pbManager.syncFromHistory).not.toHaveBeenCalled();
+      expect(bulkInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Invalid `month` format') })
+      );
+    });
+
+    it('skips members without a valid token and still syncs the rest', async () => {
+      mockMemberManager.getValidAccessToken.mockImplementation(async (member) =>
+        member.discordUserId === '222' ? null : 'valid_token'
+      );
+
+      await discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options);
+
+      expect(discordCommands.pbManager.syncFromHistory).toHaveBeenCalledTimes(1);
+      expect(discordCommands.pbManager.syncFromHistory.mock.calls[0][0]).toBe('111');
+      expect(bulkInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ embeds: expect.any(Array) })
+      );
+    });
+
+    it('continues with remaining members when one sync fails', async () => {
+      discordCommands.pbManager.syncFromHistory
+        .mockRejectedValueOnce(new Error('Strava 500'))
+        .mockResolvedValueOnce({ processed: 4, updated: 2, errors: 0 });
+
+      await discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options);
+
+      expect(discordCommands.pbManager.syncFromHistory).toHaveBeenCalledTimes(2);
+      expect(bulkInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ embeds: expect.any(Array) })
+      );
+    });
+
+    it('blocks a second concurrent team-wide sync', async () => {
+      discordCommands.bulkSyncInProgress = true;
+
+      await discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options);
+
+      expect(bulkInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('already in progress') })
+      );
+      expect(discordCommands.pbManager.syncFromHistory).not.toHaveBeenCalled();
+
+      discordCommands.bulkSyncInProgress = false;
+    });
+
+    it('releases the bulk lock after completion', async () => {
+      await discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options);
+
+      expect(discordCommands.bulkSyncInProgress).toBe(false);
+    });
+
+    it('releases the bulk lock even when member listing fails', async () => {
+      mockMemberManager.getAllMembers.mockRejectedValue(new Error('DB down'));
+
+      await discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options);
+
+      expect(discordCommands.bulkSyncInProgress).toBe(false);
+      expect(bulkInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Failed') })
+      );
+    });
+
+    it('does not take the per-user sync lock for bulk runs', async () => {
+      await discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options);
+
+      expect(discordCommands.pbSyncInProgress.has('999999999')).toBe(false);
     });
   });
 

--- a/src/discord/commands.js
+++ b/src/discord/commands.js
@@ -30,6 +30,7 @@ class DiscordCommands {
     this.pbManager = new PBManager();
     this.leaderboardManager = new LeaderboardManager();
     this.pbSyncInProgress = new Set();
+    this.bulkSyncInProgress = false;
   }
 
   // Define all slash commands
@@ -447,6 +448,12 @@ class DiscordCommands {
           option
             .setName('month')
             .setDescription('Specific calendar month in YYYY-MM (overrides period when set)')
+            .setRequired(false)
+        )
+        .addBooleanOption(option =>
+          option
+            .setName('all_members')
+            .setDescription('Run the sync for every registered member (admin only)')
             .setRequired(false)
         ),
 
@@ -1065,7 +1072,7 @@ class DiscordCommands {
       {
         name: '🏆 3. Records personnels (PB)',
         value:
-          '`/pb check` — Affiche tes records personnels (5K, 10K, semi, marathon…).\n`/pb check member:<nom>` — Affiche les records d\'un autre membre.\n`/pb add activity_url:<lien> distance_m:<mètres>` — Ajoute manuellement un PB depuis une activité Strava (utile pour les courses de plus d\'un an).\n`/sync period:<période> [month:YYYY-MM]` — Synchronise ton historique Strava et met à jour tes PB (année en cours, 365 derniers jours, mois en cours, mois précédent, ou un mois précis via `month:`).',
+          '`/pb check` — Affiche tes records personnels (5K, 10K, semi, marathon…).\n`/pb check member:<nom>` — Affiche les records d\'un autre membre.\n`/pb add activity_url:<lien> distance_m:<mètres>` — Ajoute manuellement un PB depuis une activité Strava (utile pour les courses de plus d\'un an).\n`/sync period:<période> [month:YYYY-MM]` — Synchronise ton historique Strava et met à jour tes PB (année en cours, 365 derniers jours, mois en cours, mois précédent, ou un mois précis via `month:`).\n`/sync period:<période> all_members:True` — Synchronise tous les membres de l\'équipe (admin uniquement).',
         inline: false,
       },
       {
@@ -2377,6 +2384,11 @@ class DiscordCommands {
   async handleSyncCommand(interaction, options) {
     await interaction.deferReply({ ephemeral: true });
 
+    if (options.getBoolean('all_members')) {
+      await this.handleSyncAllMembers(interaction, options);
+      return;
+    }
+
     if (this.pbSyncInProgress.has(interaction.user.id)) {
       await interaction.editReply({
         content: '⏳ A sync is already in progress for your account. Please wait for it to finish.',
@@ -2486,6 +2498,117 @@ class DiscordCommands {
       });
     } finally {
       this.pbSyncInProgress.delete(interaction.user.id);
+    }
+  }
+
+  // Team-wide sync: runs the same windowed sync for every registered member.
+  // Admin-gated and sequential on purpose — the whole bot shares one Strava
+  // rate budget, so members' syncs must not run concurrently.
+  async handleSyncAllMembers(interaction, options) {
+    if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
+      await interaction.editReply({
+        content: '❌ You need "Manage Server" permissions to sync all members.',
+      });
+      return;
+    }
+
+    if (this.bulkSyncInProgress) {
+      await interaction.editReply({
+        content: '⏳ A team-wide sync is already in progress. Please wait for it to finish.',
+      });
+      return;
+    }
+
+    const window = this.resolveSyncWindow(options.getString('period'), options.getString('month'));
+    if (window.error) {
+      await interaction.editReply({ content: window.error });
+      return;
+    }
+    const { afterTs, beforeTs, periodLabel } = window;
+
+    this.bulkSyncInProgress = true;
+    try {
+      const members = await this.activityProcessor.memberManager.getAllMembers();
+      const totals = { processed: 0, updated: 0, errors: 0 };
+      const skipped = [];
+      const failed = [];
+
+      for (const [index, member] of members.entries()) {
+        const memberName = member.discordUser?.displayName
+          || `${member.athlete.firstname} ${member.athlete.lastname}`.trim();
+
+        await this._editReplySafe(interaction, {
+          content: `⏳ Syncing **${periodLabel}** — **${memberName}** (${index + 1}/${members.length})…`,
+        });
+
+        const accessToken = await this.activityProcessor.memberManager.getValidAccessToken(member);
+        if (!accessToken) {
+          skipped.push(memberName);
+          continue;
+        }
+
+        try {
+          const summary = await this.pbManager.syncFromHistory(
+            member.discordUserId,
+            accessToken,
+            this.activityProcessor.stravaAPI,
+            null,
+            afterTs,
+            beforeTs
+          );
+          totals.processed += summary.processed;
+          totals.updated += summary.updated;
+          totals.errors += summary.errors;
+        } catch (memberError) {
+          failed.push(memberName);
+          logger.discord.error('Team-wide sync failed for member', {
+            memberName,
+            athleteId: member.athleteId,
+            error: memberError.message,
+          });
+        }
+      }
+
+      const embed = new EmbedBuilder()
+        .setTitle(`🔄 Team Sync Complete — ${periodLabel}`)
+        .setColor('#D4AF37')
+        .addFields([
+          { name: 'Members synced', value: String(members.length - skipped.length - failed.length), inline: true },
+          { name: 'Activities scanned', value: String(totals.processed), inline: true },
+          { name: 'PBs updated', value: String(totals.updated), inline: true },
+        ])
+        .setTimestamp();
+      if (skipped.length > 0) {
+        embed.addFields([{ name: '⚠️ Skipped (no valid token)', value: skipped.join(', ') }]);
+      }
+      if (failed.length > 0) {
+        embed.addFields([{ name: '❌ Failed', value: failed.join(', ') }]);
+      }
+
+      await this._editReplySafe(interaction, { content: '', embeds: [embed] });
+    } catch (error) {
+      logger.discord.error('Error running team-wide sync', {
+        user: interaction.user.tag,
+        error: error.message,
+      });
+      await this._editReplySafe(interaction, {
+        content: '❌ Failed to run the team-wide sync.',
+      });
+    } finally {
+      this.bulkSyncInProgress = false;
+    }
+  }
+
+  // A team-wide sync can outlive Discord's 15-minute interaction window, after
+  // which editReply throws — don't let a progress update kill the sync loop.
+  async _editReplySafe(interaction, payload) {
+    try {
+      await interaction.editReply(payload);
+    } catch (editErr) {
+      logger.discord.warn('editReply failed (likely past 15-min interaction window)', {
+        user: interaction.user.tag,
+        error: editErr.message,
+      });
     }
   }
 


### PR DESCRIPTION
## What

Adds an `all_members` boolean option to `/sync`, gated to **Manage Server** permission. When set, the bot runs the same windowed sync (period / `month:YYYY-MM`) sequentially for every registered member, with per-member progress updates, a global in-progress lock, and a final summary embed listing members skipped (no valid token) or failed.

## Why

`/sync` only syncs the invoking member, so recovering a data gap — like the June 2026 leaderboard loss fixed in #47 — required all 19 members to each run the command. With this, an admin runs one command:

```
/sync period:previous_month all_members:True
```

Sequential on purpose: the bot shares a single Strava rate budget (240 req/15 min), and `syncFromHistory` already paces its requests. Progress updates use a safe editReply wrapper since a team-wide run can outlive Discord's 15-minute interaction window.

## Tests

- 11 new tests covering permission gating (incl. DM context), window resolution, explicit month, skip-on-missing-token, continue-on-member-failure, concurrent-run lock, and lock release on error paths.
- Full suite: 983/983 passing; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)