### PR TITLE
fix(discord): deliver bulk sync summary after 15-min interaction window

### DIFF
--- a/__tests__/discord/commands.test.js
+++ b/__tests__/discord/commands.test.js
@@ -1770,6 +1770,72 @@ describe('DiscordCommands', () => {
         expect.objectContaining({ content: expect.stringContaining('Failed') })
       );
     });
+
+    it('falls back to DM when the summary editReply fails (past 15-min window)', async () => {
+      discordCommands.pbManager.syncFromHistory.mockResolvedValue({ processed: 10, updated: 3, errors: 0 });
+      syncInteraction.user.send = jest.fn().mockResolvedValue(undefined);
+      syncInteraction.channel = { send: jest.fn().mockResolvedValue(undefined) };
+      // First editReply (progress message) succeeds; the summary edit fails
+      syncInteraction.editReply
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValue(new Error('Invalid Webhook Token'));
+
+      await discordCommands.handleSyncCommand(syncInteraction, syncInteraction.options);
+
+      expect(syncInteraction.user.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('sync complete'),
+          embeds: expect.any(Array),
+        })
+      );
+      expect(syncInteraction.channel.send).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the channel with a mention when editReply and DM both fail', async () => {
+      discordCommands.pbManager.syncFromHistory.mockResolvedValue({ processed: 10, updated: 3, errors: 0 });
+      syncInteraction.user.send = jest.fn().mockRejectedValue(new Error('Cannot send messages to this user'));
+      syncInteraction.channel = { send: jest.fn().mockResolvedValue(undefined) };
+      syncInteraction.editReply
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValue(new Error('Invalid Webhook Token'));
+
+      await discordCommands.handleSyncCommand(syncInteraction, syncInteraction.options);
+
+      expect(syncInteraction.channel.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('<@123456789>'),
+          embeds: expect.any(Array),
+        })
+      );
+    });
+
+    it('does not throw and still releases the lock when every delivery path fails', async () => {
+      discordCommands.pbManager.syncFromHistory.mockResolvedValue({ processed: 10, updated: 3, errors: 0 });
+      syncInteraction.user.send = jest.fn().mockRejectedValue(new Error('Cannot send messages to this user'));
+      syncInteraction.channel = { send: jest.fn().mockRejectedValue(new Error('Missing Permissions')) };
+      syncInteraction.editReply
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValue(new Error('Invalid Webhook Token'));
+
+      await expect(
+        discordCommands.handleSyncCommand(syncInteraction, syncInteraction.options)
+      ).resolves.toBeUndefined();
+
+      expect(discordCommands.pbSyncInProgress.has('123456789')).toBe(false);
+    });
+
+    it('handles a missing channel (DM context) when editReply and DM fail', async () => {
+      discordCommands.pbManager.syncFromHistory.mockResolvedValue({ processed: 10, updated: 3, errors: 0 });
+      syncInteraction.user.send = jest.fn().mockRejectedValue(new Error('Cannot send messages to this user'));
+      syncInteraction.channel = null;
+      syncInteraction.editReply
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValue(new Error('Invalid Webhook Token'));
+
+      await expect(
+        discordCommands.handleSyncCommand(syncInteraction, syncInteraction.options)
+      ).resolves.toBeUndefined();
+    });
   });
 
   // ─── handleSyncCommand — all_members (admin bulk sync) ─────────────────────
@@ -1938,6 +2004,51 @@ describe('DiscordCommands', () => {
       await discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options);
 
       expect(discordCommands.pbSyncInProgress.has('999999999')).toBe(false);
+    });
+
+    it('falls back to DM when the summary editReply fails (past 15-min window)', async () => {
+      bulkInteraction.user.send = jest.fn().mockResolvedValue(undefined);
+      bulkInteraction.channel = { send: jest.fn().mockResolvedValue(undefined) };
+      bulkInteraction.editReply.mockRejectedValue(new Error('Invalid Webhook Token'));
+
+      await discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options);
+
+      // The sync itself completed for every member despite editReply failing
+      expect(discordCommands.pbManager.syncFromHistory).toHaveBeenCalledTimes(2);
+      expect(bulkInteraction.user.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('Team sync complete'),
+          embeds: expect.any(Array),
+        })
+      );
+      expect(bulkInteraction.channel.send).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the channel with a mention when editReply and DM both fail', async () => {
+      bulkInteraction.user.send = jest.fn().mockRejectedValue(new Error('Cannot send messages to this user'));
+      bulkInteraction.channel = { send: jest.fn().mockResolvedValue(undefined) };
+      bulkInteraction.editReply.mockRejectedValue(new Error('Invalid Webhook Token'));
+
+      await discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options);
+
+      expect(bulkInteraction.channel.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('<@999999999>'),
+          embeds: expect.any(Array),
+        })
+      );
+    });
+
+    it('releases the bulk lock even when every delivery path fails', async () => {
+      bulkInteraction.user.send = jest.fn().mockRejectedValue(new Error('Cannot send messages to this user'));
+      bulkInteraction.channel = { send: jest.fn().mockRejectedValue(new Error('Missing Permissions')) };
+      bulkInteraction.editReply.mockRejectedValue(new Error('Invalid Webhook Token'));
+
+      await expect(
+        discordCommands.handleSyncCommand(bulkInteraction, bulkInteraction.options)
+      ).resolves.toBeUndefined();
+
+      expect(discordCommands.bulkSyncInProgress).toBe(false);
     });
   });
 

--- a/src/discord/commands.js
+++ b/src/discord/commands.js
@@ -2455,38 +2455,11 @@ class DiscordCommands {
         ])
         .setTimestamp();
 
-      // Try the interaction reply first. If we've crossed Discord's 15-min
-      // interaction window, editReply will throw — fall back to DMing the user
-      // and, if that also fails, posting in the originating channel so the
-      // user actually sees that the sync finished.
-      try {
-        await interaction.editReply({ content: '', embeds: [embed] });
-      } catch (editErr) {
-        logger.discord.warn('Sync editReply failed (likely past 15-min interaction window), falling back', {
-          user: interaction.user.tag,
-          error: editErr.message,
-        });
-        const fallbackContent = `🔄 **${periodLabel} sync complete** — ${summary.processed} scanned, ${summary.updated} PBs updated, ${summary.errors} errors.`;
-        try {
-          await interaction.user.send({ content: fallbackContent, embeds: [embed] });
-        } catch (dmErr) {
-          logger.discord.warn('Sync fallback DM failed, posting in channel', {
-            user: interaction.user.tag,
-            error: dmErr.message,
-          });
-          try {
-            await interaction.channel?.send({
-              content: `<@${interaction.user.id}> ${fallbackContent}`,
-              embeds: [embed],
-            });
-          } catch (chErr) {
-            logger.discord.error('Sync fallback channel post failed; summary not delivered to user', {
-              user: interaction.user.tag,
-              error: chErr.message,
-            });
-          }
-        }
-      }
+      await this._deliverSyncSummary(
+        interaction,
+        `🔄 **${periodLabel} sync complete** — ${summary.processed} scanned, ${summary.updated} PBs updated, ${summary.errors} errors.`,
+        embed
+      );
 
     } catch (error) {
       logger.discord.error('Error syncing PBs', {
@@ -2585,7 +2558,12 @@ class DiscordCommands {
         embed.addFields([{ name: '❌ Failed', value: failed.join(', ') }]);
       }
 
-      await this._editReplySafe(interaction, { content: '', embeds: [embed] });
+      const syncedCount = members.length - skipped.length - failed.length;
+      await this._deliverSyncSummary(
+        interaction,
+        `🔄 **Team sync complete — ${periodLabel}** — ${syncedCount} members synced, ${totals.processed} activities scanned, ${totals.updated} PBs updated.`,
+        embed
+      );
     } catch (error) {
       logger.discord.error('Error running team-wide sync', {
         user: interaction.user.tag,
@@ -2609,6 +2587,40 @@ class DiscordCommands {
         user: interaction.user.tag,
         error: editErr.message,
       });
+    }
+  }
+
+  // Deliver a sync summary through the interaction reply first. If we've
+  // crossed Discord's 15-min interaction window, editReply throws — fall back
+  // to DMing the user and, if that also fails, posting in the originating
+  // channel so the user actually sees that the sync finished.
+  async _deliverSyncSummary(interaction, fallbackContent, embed) {
+    try {
+      await interaction.editReply({ content: '', embeds: [embed] });
+    } catch (editErr) {
+      logger.discord.warn('Sync editReply failed (likely past 15-min interaction window), falling back', {
+        user: interaction.user.tag,
+        error: editErr.message,
+      });
+      try {
+        await interaction.user.send({ content: fallbackContent, embeds: [embed] });
+      } catch (dmErr) {
+        logger.discord.warn('Sync fallback DM failed, posting in channel', {
+          user: interaction.user.tag,
+          error: dmErr.message,
+        });
+        try {
+          await interaction.channel?.send({
+            content: `<@${interaction.user.id}> ${fallbackContent}`,
+            embeds: [embed],
+          });
+        } catch (chErr) {
+          logger.discord.error('Sync fallback channel post failed; summary not delivered to user', {
+            user: interaction.user.tag,
+            error: chErr.message,
+          });
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

Last night's team-wide sync (`/sync period:previous_month all_members:True`) completed successfully for all 19 members, but the progress message froze at "Amraz (13/19)" and the final summary embed never appeared. Logs show `Invalid Webhook Token` — the run took ~16 minutes (Strava rate-limit pacing), past Discord's 15-minute interaction token lifetime, so every `editReply` after that point failed. The bulk path swallowed those failures by design (`_editReplySafe`) but had no other way to deliver the summary.

The per-user `/sync` already had an editReply → DM → channel fallback for exactly this case; the bulk path just never got it.

## Fix

- Extract the per-user fallback into a shared `_deliverSyncSummary(interaction, fallbackContent, embed)` helper (editReply first, then DM, then channel post with a mention; each failure logged).
- Use it for both the per-user and team-wide sync summaries.
- `_editReplySafe` stays for progress updates, which are fine to drop.

## Tests

7 new tests (990 total, all passing): fallback to DM, fallback to channel with mention, no-throw + lock release when every path fails, missing channel (DM context) — for both the per-user and bulk paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)