### PR TITLE
fix(security): fail fast on malformed ENCRYPTION_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,11 +102,11 @@ HEALTH_CHECK_DISCORD_NOTIFY=true
 
 # Security
 # Encryption Key for secure storage of member tokens
-# Generate a 32-character (64 hex) encryption key with:
+# Generate a 32-byte encryption key (64 hex characters) with:
 # node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 # This key is used to encrypt/decrypt Strava tokens stored in the database
 # IMPORTANT: Keep this key secret and don't change it after setup (you'll lose encrypted data)
-ENCRYPTION_KEY=your_32_character_encryption_key_here
+ENCRYPTION_KEY=your_64_character_hex_encryption_key_here
 
 # Optional: Database Configuration (if using external DB later)
 # DATABASE_URL=your_database_url_here

--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -1,0 +1,57 @@
+const REQUIRED_ENV = {
+  DISCORD_TOKEN: 'test-discord-token',
+  STRAVA_CLIENT_ID: 'test-client-id',
+  STRAVA_CLIENT_SECRET: 'test-client-secret',
+  STRAVA_WEBHOOK_VERIFY_TOKEN: 'test-webhook-token',
+  // 64 hex chars = 32 bytes, valid for AES-256-GCM
+  ENCRYPTION_KEY: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+};
+
+describe('config', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    for (const key of Object.keys(REQUIRED_ENV)) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('loads successfully with a valid 64-character hex ENCRYPTION_KEY', () => {
+    Object.assign(process.env, REQUIRED_ENV);
+
+    let config;
+    expect(() => {
+      config = require('../config/config');
+    }).not.toThrow();
+
+    expect(config.security.encryptionKey).toBe(REQUIRED_ENV.ENCRYPTION_KEY);
+  });
+
+  it('exits the process when ENCRYPTION_KEY is the wrong length', () => {
+    Object.assign(process.env, REQUIRED_ENV, { ENCRYPTION_KEY: 'tooshort' });
+
+    expect(() => {
+      require('../config/config');
+    }).toThrow('Process exited with code: 1');
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('ENCRYPTION_KEY'));
+  });
+
+  it('exits the process when ENCRYPTION_KEY is not valid hex', () => {
+    Object.assign(process.env, REQUIRED_ENV, {
+      ENCRYPTION_KEY: 'not-a-hex-string-at-all-not-a-hex-string-at-all-not-a-hex-strin'
+    });
+
+    expect(() => {
+      require('../config/config');
+    }).toThrow('Process exited with code: 1');
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('ENCRYPTION_KEY'));
+  });
+});

--- a/__tests__/database/DatabaseManager.simple.test.js
+++ b/__tests__/database/DatabaseManager.simple.test.js
@@ -80,6 +80,7 @@ const config = require('../../config/config');
 const logger = require('../../src/utils/Logger');
 const dbConnection = require('../../src/database/connection');
 const SettingsManager = require('../../src/managers/SettingsManager');
+const EncryptionUtils = require('../../src/utils/EncryptionUtils');
 
 // Import the real DatabaseManager to test
 const DatabaseManager = require('../../src/database/DatabaseManager');
@@ -209,11 +210,33 @@ describe('DatabaseManager', () => {
         .mockResolvedValueOnce(mockMember); // getMemberByAthleteId - returns new member
 
       const result = await DatabaseManager.registerMember(discordUserId, athlete, tokenData);
-      
+
       expect(result).toBeDefined();
       expect(result.athleteId).toBe(parseInt(athlete.id));
       expect(result.discordUserId).toBe(discordUserId);
       expect(mockDb.insert).toHaveBeenCalled();
+    });
+
+    it('should throw and not insert the member when token encryption fails', async () => {
+      const discordUserId = 'discord123';
+      const athlete = { id: 12345, firstname: 'John', lastname: 'Doe' };
+      const tokenData = { access_token: 'token', refresh_token: 'refresh' };
+
+      mockDb.get
+        .mockResolvedValueOnce(null) // getMemberByDiscordId - no existing
+        .mockResolvedValueOnce(null); // getMemberByAthleteId - no existing
+
+      jest.spyOn(EncryptionUtils, 'encryptTokensToJSON').mockImplementation(() => {
+        throw new Error('Invalid key length');
+      });
+
+      await expect(
+        DatabaseManager.registerMember(discordUserId, athlete, tokenData)
+      ).rejects.toThrow('Invalid key length');
+
+      expect(mockDb.insert).not.toHaveBeenCalled();
+
+      EncryptionUtils.encryptTokensToJSON.mockRestore();
     });
 
     it('should get member by athlete ID', async () => {

--- a/config/config.js
+++ b/config/config.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+const { ENCRYPTION } = require('../src/constants');
 
 const config = {
   discord: {
@@ -81,6 +82,20 @@ if (missingEnvVars.length > 0) {
   console.error('❌ Missing required environment variables:');
   missingEnvVars.forEach(envVar => console.error(`   - ${envVar}`));
   console.error('Please check your .env file and ensure all required variables are set.');
+  process.exit(1);
+}
+
+// ENCRYPTION_KEY must be exactly KEY_LENGTH bytes, hex-encoded, for AES-256-GCM.
+// A wrong-length key throws at encrypt/decrypt time deep in EncryptionUtils,
+// which registerMember used to swallow silently — validate it up front instead.
+const expectedKeyHexLength = ENCRYPTION.KEY_LENGTH * 2;
+const encryptionKey = process.env.ENCRYPTION_KEY;
+if (!/^[0-9a-fA-F]+$/.test(encryptionKey) || encryptionKey.length !== expectedKeyHexLength) {
+  console.error(
+    `❌ ENCRYPTION_KEY must be exactly ${expectedKeyHexLength} hex characters ` +
+    `(${ENCRYPTION.KEY_LENGTH} bytes for AES-256-GCM), got ${encryptionKey.length}.`
+  );
+  console.error('   Generate one with: node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'hex\'))"');
   process.exit(1);
 }
 

--- a/src/database/DatabaseManager.js
+++ b/src/database/DatabaseManager.js
@@ -251,6 +251,7 @@ class DatabaseManager {
           athleteId,
           error: error.message
         });
+        throw error;
       }
     } else {
       logger.database.warn('Tokens not encrypted - missing encryption key or tokenData', {

--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ Environment Variables:
   STRAVA_CLIENT_ID           Strava API client ID
   STRAVA_CLIENT_SECRET       Strava API client secret
   STRAVA_WEBHOOK_VERIFY_TOKEN Strava webhook verification token
-  ENCRYPTION_KEY             32-character hex key for encrypting member data
+  ENCRYPTION_KEY             64-character hex key (32 bytes) for encrypting member data
   PORT                       Server port (default: 3000)
   NODE_ENV                   Environment (development/production)
 


### PR DESCRIPTION
## Summary
- `registerMember` caught token-encryption errors, logged them, and still inserted the member with `encrypted_tokens: null` — a bad `ENCRYPTION_KEY` produced a "successful" `/register` that immediately needed re-auth. It now re-throws, matching `updateTokens`'s existing behavior.
- `config/config.js` validates `ENCRYPTION_KEY` is exactly 64 hex chars (32 bytes for AES-256-GCM) at startup and exits with a clear error, instead of failing silently deep inside `EncryptionUtils`.
- Corrected docs (`src/index.js`, `.env.example`) that said "32-character" key.

## Test plan
- [x] `npm test` — full suite passes
- [x] `npm run lint` — clean
- [x] New tests cover: valid key loads config successfully, wrong-length key exits process, non-hex key exits process, `registerMember` rejects and does not insert when encryption fails