### PR TITLE
fix(register): allow relinking when stored Strava tokens stop working

### DIFF
--- a/__tests__/database/DatabaseManager.simple.test.js
+++ b/__tests__/database/DatabaseManager.simple.test.js
@@ -80,6 +80,7 @@ const config = require('../../config/config');
 const logger = require('../../src/utils/Logger');
 const dbConnection = require('../../src/database/connection');
 const SettingsManager = require('../../src/managers/SettingsManager');
+const EncryptionUtils = require('../../src/utils/EncryptionUtils');
 
 // Import the real DatabaseManager to test
 const DatabaseManager = require('../../src/database/DatabaseManager');
@@ -214,6 +215,63 @@ describe('DatabaseManager', () => {
       expect(result.athleteId).toBe(parseInt(athlete.id));
       expect(result.discordUserId).toBe(discordUserId);
       expect(mockDb.insert).toHaveBeenCalled();
+    });
+
+    it('should relink an existing member with fresh tokens and athlete/discord info', async () => {
+      const existingAthleteId = 12345;
+      const athlete = { id: 12345, firstname: 'John', lastname: 'Doe' };
+      const tokenData = { access_token: 'new_token', refresh_token: 'new_refresh' };
+      const discordUser = { username: 'jdoe', displayName: 'J Doe', discriminator: '0', avatar: 'abc' };
+
+      const mockUpdateChain = {
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue(undefined)
+      };
+      mockDb.update.mockReturnValue(mockUpdateChain);
+
+      const mockSelectChain = {
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue({
+          athlete_id: existingAthleteId,
+          discord_id: 'discord123',
+          athlete: JSON.stringify(athlete),
+          is_active: 1,
+          encrypted_tokens: JSON.stringify({ iv: 'iv', encrypted: 'enc', authTag: 'tag' })
+        })
+      };
+      mockDb.select.mockReturnValue(mockSelectChain);
+
+      const result = await DatabaseManager.relinkMember(existingAthleteId, athlete, tokenData, discordUser);
+
+      expect(mockDb.update).toHaveBeenCalled();
+      expect(mockUpdateChain.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          athlete: JSON.stringify(athlete),
+          discord_username: 'jdoe',
+          encrypted_tokens: expect.any(String)
+        })
+      );
+      expect(result.athleteId).toBe(existingAthleteId);
+      expect(result.discordUserId).toBe('discord123');
+    });
+
+    it('should throw and not update the row when token encryption fails during relink', async () => {
+      const existingAthleteId = 12345;
+      const athlete = { id: 12345, firstname: 'John', lastname: 'Doe' };
+      const tokenData = { access_token: 'token' };
+
+      jest.spyOn(EncryptionUtils, 'encryptTokensToJSON').mockImplementation(() => {
+        throw new Error('Invalid key length');
+      });
+
+      await expect(
+        DatabaseManager.relinkMember(existingAthleteId, athlete, tokenData)
+      ).rejects.toThrow('Invalid key length');
+
+      expect(mockDb.update).not.toHaveBeenCalled();
+
+      EncryptionUtils.encryptTokensToJSON.mockRestore();
     });
 
     it('should get member by athlete ID', async () => {

--- a/__tests__/database/DatabaseMemberManager.test.js
+++ b/__tests__/database/DatabaseMemberManager.test.js
@@ -13,6 +13,7 @@ jest.mock('../../config/config', () => ({
 const mockDatabaseManager = {
   initialize: jest.fn().mockResolvedValue(undefined),
   registerMember: jest.fn(),
+  relinkMember: jest.fn(),
   getMemberByAthleteId: jest.fn(),
   getMemberByDiscordId: jest.fn(),
   getAllMembers: jest.fn(),
@@ -78,6 +79,43 @@ describe('DatabaseMemberManager', () => {
       await memberManager.registerMember('discord123', mockAthlete, mockTokenData);
 
       expect(mockDatabaseManager.registerMember).toHaveBeenCalledWith('discord123', mockAthlete, mockTokenData, null);
+    });
+
+    it('should relink an existing active member whose stored tokens no longer work', async () => {
+      const existingMember = { athleteId: 12345, discordUserId: 'discord123', isActive: true, tokens: { encrypted: 'data' } };
+      mockDatabaseManager.getMemberByDiscordId.mockResolvedValue(existingMember);
+      jest.spyOn(memberManager, 'getValidAccessToken').mockResolvedValue(null);
+      mockDatabaseManager.relinkMember.mockResolvedValue({ athleteId: 12345, discordUserId: 'discord123' });
+
+      const result = await memberManager.registerMember('discord123', mockAthlete, mockTokenData, mockDiscordUser);
+
+      expect(mockDatabaseManager.relinkMember).toHaveBeenCalledWith(12345, mockAthlete, mockTokenData, mockDiscordUser);
+      expect(mockDatabaseManager.registerMember).not.toHaveBeenCalled();
+      expect(result.athleteId).toBe(12345);
+    });
+
+    it('should throw already-registered when an existing active member still has valid tokens', async () => {
+      const existingMember = { athleteId: 12345, discordUserId: 'discord123', isActive: true, tokens: { encrypted: 'data' } };
+      mockDatabaseManager.getMemberByDiscordId.mockResolvedValue(existingMember);
+      jest.spyOn(memberManager, 'getValidAccessToken').mockResolvedValue('valid_access_token');
+
+      await expect(
+        memberManager.registerMember('discord123', mockAthlete, mockTokenData, mockDiscordUser)
+      ).rejects.toThrow();
+
+      expect(mockDatabaseManager.relinkMember).not.toHaveBeenCalled();
+    });
+
+    it('should not attempt a relink for an existing inactive member', async () => {
+      const existingMember = { athleteId: 12345, discordUserId: 'discord123', isActive: false, tokens: null };
+      mockDatabaseManager.getMemberByDiscordId.mockResolvedValue(existingMember);
+      mockDatabaseManager.registerMember.mockRejectedValue(new Error('Discord user discord123 is already registered'));
+
+      await expect(
+        memberManager.registerMember('discord123', mockAthlete, mockTokenData, mockDiscordUser)
+      ).rejects.toThrow('already registered');
+
+      expect(mockDatabaseManager.relinkMember).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/discord/commands.test.js
+++ b/__tests__/discord/commands.test.js
@@ -934,12 +934,14 @@ describe('DiscordCommands', () => {
       });
     });
 
-    it('should handle already registered user', async () => {
+    it('should handle already registered user with a working Strava connection', async () => {
       mockMemberManager.getMemberByDiscordId.mockResolvedValue(mockMember);
+      mockMemberManager.getValidAccessToken.mockResolvedValue('valid_token');
 
       await discordCommands.handleRegisterCommand(mockInteraction);
 
       expect(mockInteraction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+      expect(mockMemberManager.getValidAccessToken).toHaveBeenCalledWith(mockMember);
       expect(mockInteraction.editReply).toHaveBeenCalledWith({
         content: '✅ You\'re already registered as **Test User**.'
       });
@@ -951,12 +953,37 @@ describe('DiscordCommands', () => {
         discordUser: null
       };
       mockMemberManager.getMemberByDiscordId.mockResolvedValue(memberWithoutDisplayName);
+      mockMemberManager.getValidAccessToken.mockResolvedValue('valid_token');
 
       await discordCommands.handleRegisterCommand(mockInteraction);
 
       expect(mockInteraction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
       expect(mockInteraction.editReply).toHaveBeenCalledWith({
         content: '✅ You\'re already registered as **John Doe**.'
+      });
+    });
+
+    it('should offer a fresh registration link when an active member has no working Strava tokens', async () => {
+      mockMemberManager.getMemberByDiscordId.mockResolvedValue(mockMember);
+      mockMemberManager.getValidAccessToken.mockResolvedValue(null);
+
+      await discordCommands.handleRegisterCommand(mockInteraction);
+
+      expect(mockMemberManager.getValidAccessToken).toHaveBeenCalledWith(mockMember);
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        embeds: [expect.any(Object)]
+      });
+    });
+
+    it('should still block re-registration for a deactivated member, even without a token check', async () => {
+      const inactiveMember = { ...mockMember, isActive: false };
+      mockMemberManager.getMemberByDiscordId.mockResolvedValue(inactiveMember);
+
+      await discordCommands.handleRegisterCommand(mockInteraction);
+
+      expect(mockMemberManager.getValidAccessToken).not.toHaveBeenCalled();
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        content: '✅ You\'re already registered as **Test User**.'
       });
     });
   });

--- a/src/database/DatabaseManager.js
+++ b/src/database/DatabaseManager.js
@@ -292,6 +292,47 @@ class DatabaseManager {
     return newMember;
   }
 
+  // Re-link an existing member to a fresh Strava OAuth grant (new tokens, refreshed
+  // athlete/Discord info) without touching athlete_id or is_active. Used when a member's
+  // stored tokens have become unusable (e.g. ENCRYPTION_KEY rotation, access revoked on
+  // Strava) so they can recover via /register instead of being stuck as "already registered".
+  async relinkMember(athleteId, athlete, tokenData, discordUser = null) {
+    await this.ensureInitialized();
+
+    let encryptedTokens = null;
+    if (tokenData && config.security.encryptionKey) {
+      try {
+        encryptedTokens = EncryptionUtils.encryptTokensToJSON(tokenData);
+      } catch (error) {
+        logger.database.error('Failed to encrypt tokens during relink', {
+          athleteId,
+          error: error.message
+        });
+        throw error;
+      }
+    }
+
+    await this.db.update(members)
+      .set({
+        athlete: JSON.stringify(athlete),
+        discord_username: discordUser?.username || null,
+        discord_display_name: discordUser?.globalName || discordUser?.displayName || null,
+        discord_discriminator: discordUser?.discriminator || '0',
+        discord_avatar: discordUser?.avatar || null,
+        encrypted_tokens: encryptedTokens,
+        updated_at: new Date().toISOString()
+      })
+      .where(eq(members.athlete_id, athleteId));
+
+    const updatedMember = await this.getMemberByAthleteId(athleteId);
+
+    logger.memberAction('RELINKED', `${athlete.firstname} ${athlete.lastname}`, updatedMember.discordUserId, athleteId, {
+      relinkedAt: updatedMember.lastTokenRefresh
+    });
+
+    return updatedMember;
+  }
+
   async getMemberByAthleteId(athleteId) {
     await this.ensureInitialized();
     

--- a/src/database/DatabaseMemberManager.js
+++ b/src/database/DatabaseMemberManager.js
@@ -23,6 +23,24 @@ class DatabaseMemberManager {
   
   async registerMember(discordUserId, athlete, tokenData, discordUser = null) {
     await this.ensureInitialized();
+
+    const existingMember = await this.getMemberByDiscordId(discordUserId);
+    if (existingMember) {
+      const validToken = existingMember.isActive
+        ? await this.getValidAccessToken(existingMember)
+        : null;
+
+      if (!existingMember.isActive || validToken) {
+        throw new Error(`Discord user ${discordUserId} is already registered`);
+      }
+
+      logger.database.warn('Relinking member with unusable stored tokens', {
+        discordUserId,
+        athleteId: existingMember.athleteId
+      });
+      return await this.databaseManager.relinkMember(existingMember.athleteId, athlete, tokenData, discordUser);
+    }
+
     return await this.databaseManager.registerMember(discordUserId, athlete, tokenData, discordUser);
   }
 

--- a/src/discord/commands.js
+++ b/src/discord/commands.js
@@ -1022,10 +1022,21 @@ class DiscordCommands {
 
     if (existingMember) {
       const memberName = existingMember.discordUser ? existingMember.discordUser.displayName : `${existingMember.athlete.firstname} ${existingMember.athlete.lastname}`;
-      await interaction.editReply({
-        content: `✅ You're already registered as **${memberName}**.`
-      });
-      return;
+
+      // Deactivated members stay blocked (needs admin /reactivate first). Active members
+      // only stay blocked if their stored tokens actually still work — otherwise (e.g. after
+      // an ENCRYPTION_KEY rotation, or the user revoking access on Strava) fall through and
+      // offer a fresh OAuth link so they can relink instead of being stuck.
+      const hasValidToken = existingMember.isActive
+        ? await this.activityProcessor.memberManager.getValidAccessToken(existingMember)
+        : null;
+
+      if (!existingMember.isActive || hasValidToken) {
+        await interaction.editReply({
+          content: `✅ You're already registered as **${memberName}**.`
+        });
+        return;
+      }
     }
 
     const registerUrl = `${config.server.baseUrl}/auth/strava?user_id=${userId}`;


### PR DESCRIPTION
## Summary
- `/register` only checked whether a member row existed for the Discord user, so anyone whose tokens became unusable (`ENCRYPTION_KEY` rotation, access revoked on Strava) got "✅ already registered" from `/register` while every other command told them to `/register` — a dead end with no way out.
- `/register` now checks token validity for active members via `getValidAccessToken`: if tokens still work, behavior is unchanged; if not, it offers a fresh OAuth link.
- Completing that OAuth flow now relinks the existing member (new tokens, refreshed athlete/Discord info) via a new `DatabaseManager.relinkMember`, instead of `registerMember` rejecting with "already registered".
- Deactivated members are unaffected — still blocked, still require admin `/reactivate` first.

## Test plan
- [x] `npm test` — full suite passes
- [x] `npm run lint` — clean
- [x] New tests cover: `/register` relink offer vs. already-registered vs. deactivated-blocked; `DatabaseMemberManager.registerMember` relink/throw/inactive paths; `DatabaseManager.relinkMember` update + encryption-failure re-throw